### PR TITLE
Find SC_PATH with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,15 @@ if (APPLE)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}")
 endif()
 
-include_directories(${SC_PATH}/include/plugin_interface)
-include_directories(${SC_PATH}/include/common)
+find_path(SC_PATH NAMES plugin_interface/SC_PlugIn.h PATH_SUFFIXES SuperCollider)
+if(NOT SC_PATH)
+    message(FATAL_ERROR "SuperCollider headers not found. Please install SuperCollider.")
+else()
+    message("Found SuperCollider headers: ${SC_PATH}")
+endif()
+include_directories(${SC_PATH}/plugin_interface)
 include_directories(${SC_PATH}/common)
+
 include_directories(/usr/local/include)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux|.*BSD|DragonFly")

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A SuperCollider UGen for using libmapper
 
 ## Installation
+* Install [SuperCollider](https://supercollider.github.io/)
 * Build and install [libmapper](https://github.com/libmapper/libmapper)
 * Unzip MapperUGen.zip from [releases](https://github.com/mathiasbredholt/MapperUGen/releases) into SuperCollider extensions folder (Platform.userExtensionDir)
 
@@ -10,6 +11,6 @@ A SuperCollider UGen for using libmapper
 * Run
 ```
 mkdir build && cd build
-cmake -DSC_PATH=/path/to/sc/ -DSUPERNOVA=ON ..
+cmake -DSUPERNOVA=ON ..
 cmake --build . --target install
 ```


### PR DESCRIPTION
Hey @mathiasbredholt,

On Ubuntu/Pop!_OS 20.04 SuperCollider headers are located under: `/usr/include/SuperCollider/plugin_interface/`, `/usr/include/SuperCollider/common/`, which can not be described with `${SC_PATH}/include/plugin_interface` and `${SC_PATH}/include/common`.

I propose in this pull request to use `find_path` towards a cross-platform and automated solution.

Kind regards,
Christian