### PR TITLE
Downgrade boost to 1.71.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT MAPPER_LIB)
   message(FATAL_ERROR "libmapper library not found")
 endif()
 
-find_package(Boost 1.73.0 REQUIRED)
+find_package(Boost 1.71.0 REQUIRED)
 if(NOT Boost_FOUND)
   message(FATAL_ERROR "boost library not found")
 endif()


### PR DESCRIPTION
Hi @mathiasbredholt 

I propose to downgrade boost required version from 1.73.0 to 1.71.0 so that MapperUGen also compiles on Ubuntu 20.04 LTS.

boost/lockfree/queue.hpp used in MapperUGen looks identical between boost lockfree lib versions 1.71.0 and 1.73.0:
https://github.com/boostorg/lockfree/blob/boost-1.71.0/include/boost/lockfree/queue.hpp
https://github.com/boostorg/lockfree/blob/boost-1.73.0/include/boost/lockfree/queue.hpp

Did you have a specific motivation for requiring boost 1.73.0 other than the version available on your system?

Kind regards,
Christian